### PR TITLE
feat: create routes module

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	"git.licolas.net/delegit/delegit/database"
+	"git.licolas.net/delegit/delegit/routes"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
@@ -41,91 +41,10 @@ func main() {
 		logger.Fatal().Err(err).Msg("unable to get database")
 	}
 
-	router := gin.Default()
-	router.GET("/feedback", func(ctx *gin.Context) {
-		feedback, err := db.GetAllFeedback()
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err})
-		}
-		ctx.JSON(http.StatusOK, feedback)
-	})
+	r := gin.Default()
+	routes.RegisterFeedbackEndpoints(db, r)
 
-	router.POST("/feedback", func(ctx *gin.Context) {
-		var feedback database.Feedback
-		if err := ctx.ShouldBind(&feedback); err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-			return
-		}
-
-		f, err := db.AddFeedback(&feedback)
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
-			return
-		}
-		ctx.JSON(http.StatusOK, f)
-	})
-
-	router.GET("/feedback/:id", func(ctx *gin.Context) {
-		_id, err := strconv.ParseUint(ctx.Param("id"), 10, 32)
-		id := uint(_id)
-		logger.Debug().Uint("feedback", id).Msg("looking for feedback by ID")
-
-		if err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-			return
-		}
-
-		feedback, err := db.GetFeedback(id)
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err})
-			return
-		}
-		ctx.JSON(http.StatusOK, feedback)
-	})
-
-	router.PUT("/feedback", func(ctx *gin.Context) {
-		var feedback *database.Feedback
-		if err := ctx.ShouldBind(feedback); err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-			return
-		}
-
-		feedback, err := db.UpdateFeedback(feedback)
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err})
-			return
-		}
-		ctx.JSON(http.StatusOK, feedback)
-	})
-
-	router.DELETE("/feedback", func(ctx *gin.Context) {
-		var feedback *database.Feedback
-		if err := ctx.ShouldBind(feedback); err != nil {
-			ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
-			return
-		}
-
-		if err := db.DeleteFeedback(feedback); err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err})
-			return
-		}
-
-		feedback.ID = 0
-		ctx.JSON(http.StatusOK, feedback)
-	})
-
-	router.OPTIONS("/feedback", func(ctx *gin.Context) {
-		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Autorization")
-		ctx.Writer.Header().Set("Access-Control-Max-Age", "300")
-		ctx.AbortWithStatus(http.StatusNoContent)
-	})
-
-	err = http.ListenAndServe(
-		fmt.Sprintf("%s:%d", host, port),
-		router,
-	)
+	err = http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), r)
 
 	fmt.Printf("%e\n", err)
 }

--- a/routes/feedback.go
+++ b/routes/feedback.go
@@ -175,14 +175,14 @@ func RegisterFeedbackEndpoints(database *database.Database, router *gin.Engine) 
 
 	router.Use(CommonHeaders)
 
-	router.GET("/feedback", getAllFeedback)
-	router.POST("/feedback", postFeedback)
-	router.OPTIONS("/feedback", optionsFeedbackList)
+	router.GET("/feedback", optionsFeedbackList, getAllFeedback)
+	router.POST("/feedback", optionsFeedbackList, postFeedback)
+	router.OPTIONS("/feedback", optionsFeedbackList, Terminate)
 
-	router.GET("/feedback/:id", getFeedback)
-	router.PATCH("/feedback/:id/upvote", updateFeedbackUpvotes)
-	router.PATCH("/feedback/:id/downvote", updateFeedbackDownvotes)
-	router.PUT("/feedback/:id", putFeedback)
-	router.DELETE("/feedback/:id", deleteFeedback)
-	router.OPTIONS("/feedback/:id", optionsFeedbackEntry)
+	router.GET("/feedback/:id", optionsFeedbackEntry, getFeedback)
+	router.PATCH("/feedback/:id/upvote", optionsFeedbackEntry, updateFeedbackUpvotes)
+	router.PATCH("/feedback/:id/downvote", optionsFeedbackEntry, updateFeedbackDownvotes)
+	router.PUT("/feedback/:id", optionsFeedbackEntry, putFeedback)
+	router.DELETE("/feedback/:id", optionsFeedbackEntry, deleteFeedback)
+	router.OPTIONS("/feedback/:id", optionsFeedbackEntry, Terminate)
 }

--- a/routes/feedback.go
+++ b/routes/feedback.go
@@ -172,13 +172,12 @@ func RegisterFeedbackEndpoints(database *database.Database, router *gin.Engine) 
 	db = database
 
 	list := router.Group("/feedback")
-	list.Use(CommonHeaders)
+	list.Use(CommonHeaders, optionsFeedbackList)
+	list.GET("/", getAllFeedback)
+	list.POST("/", postFeedback)
+	list.OPTIONS("/", Terminate)
 
-	list.GET("/", optionsFeedbackList, getAllFeedback)
-	list.POST("/", optionsFeedbackList, postFeedback)
-	list.OPTIONS("/", optionsFeedbackList, Terminate)
-
-	entry := list.Group("/:id")
+	entry := router.Group("/feedback/:id")
 	entry.Use(optionsFeedbackEntry)
 	entry.GET("/", getFeedback)
 	entry.PATCH("/upvote", updateFeedbackUpvotes)

--- a/routes/feedback.go
+++ b/routes/feedback.go
@@ -171,16 +171,19 @@ func updateFeedbackDownvotes(ctx *gin.Context) {
 func RegisterFeedbackEndpoints(database *database.Database, router *gin.Engine) {
 	db = database
 
-	router.Use(CommonHeaders)
+	list := router.Group("/feedback")
+	list.Use(CommonHeaders)
 
-	router.GET("/feedback", optionsFeedbackList, getAllFeedback)
-	router.POST("/feedback", optionsFeedbackList, postFeedback)
-	router.OPTIONS("/feedback", optionsFeedbackList, Terminate)
+	list.GET("/", optionsFeedbackList, getAllFeedback)
+	list.POST("/", optionsFeedbackList, postFeedback)
+	list.OPTIONS("/", optionsFeedbackList, Terminate)
 
-	router.GET("/feedback/:id", optionsFeedbackEntry, getFeedback)
-	router.PATCH("/feedback/:id/upvote", optionsFeedbackEntry, updateFeedbackUpvotes)
-	router.PATCH("/feedback/:id/downvote", optionsFeedbackEntry, updateFeedbackDownvotes)
-	router.PUT("/feedback/:id", optionsFeedbackEntry, putFeedback)
-	router.DELETE("/feedback/:id", optionsFeedbackEntry, deleteFeedback)
-	router.OPTIONS("/feedback/:id", optionsFeedbackEntry, Terminate)
+	entry := list.Group("/:id")
+	entry.Use(optionsFeedbackEntry)
+	entry.GET("/", getFeedback)
+	entry.PATCH("/upvote", updateFeedbackUpvotes)
+	entry.PATCH("/downvote", updateFeedbackDownvotes)
+	entry.PUT("/", putFeedback)
+	entry.DELETE("/", deleteFeedback)
+	entry.OPTIONS("/", Terminate)
 }

--- a/routes/feedback.go
+++ b/routes/feedback.go
@@ -1,0 +1,117 @@
+/**
+ * file: router/feedback.go
+ * author: theo technicguy
+ * license: apache-2.0
+ *
+ * This file contains all routes leading to
+ * the feedback endpoints.
+ */
+
+package routes
+
+import (
+	"net/http"
+	"strconv"
+
+	"git.licolas.net/delegit/delegit/database"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	db *database.Database
+)
+
+func getAllFeedback(ctx *gin.Context) {
+	feedback, err := db.GetAllFeedback()
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err})
+	}
+	ctx.JSON(http.StatusOK, feedback)
+}
+
+func postFeedback(ctx *gin.Context) {
+	var feedback database.Feedback
+	if err := ctx.ShouldBind(&feedback); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	f, err := db.AddFeedback(&feedback)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, f)
+}
+
+func getFeedback(ctx *gin.Context) {
+	_id, err := strconv.ParseUint(ctx.Param("id"), 10, 32)
+	id := uint(_id)
+
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	feedback, err := db.GetFeedback(id)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, feedback)
+}
+
+func putFeedback(ctx *gin.Context) {
+	var feedback *database.Feedback
+	if err := ctx.ShouldBind(&feedback); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	feedback, err := db.UpdateFeedback(feedback)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, feedback)
+}
+
+func deleteFeedback(ctx *gin.Context) {
+	var feedback *database.Feedback
+	if err := ctx.ShouldBind(&feedback); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
+		return
+	}
+
+	if err := db.DeleteFeedback(feedback); err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+
+	feedback.ID = 0
+	ctx.JSON(http.StatusOK, feedback)
+}
+
+func optionsFeedbackList(ctx *gin.Context) {
+	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	ctx.AbortWithStatus(http.StatusNoContent)
+}
+
+func optionsFeedbackEntry(ctx *gin.Context) {
+	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+	ctx.AbortWithStatus(http.StatusNoContent)
+}
+
+func RegisterFeedbackEndpoints(database *database.Database, router *gin.Engine) {
+	db = database
+
+	router.Use(CommonHeaders)
+
+	router.GET("/feedback", getAllFeedback)
+	router.GET("/feedback/:id", getFeedback)
+	router.POST("/feedback", postFeedback)
+	router.PUT("/feedback/:id", putFeedback)
+	router.DELETE("/feedback/:id", deleteFeedback)
+	router.OPTIONS("/feedback", optionsFeedbackList)
+	router.OPTIONS("/feedback/:id", optionsFeedbackEntry)
+}

--- a/routes/feedback.go
+++ b/routes/feedback.go
@@ -94,12 +94,10 @@ func deleteFeedback(ctx *gin.Context) {
 
 func optionsFeedbackList(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	ctx.AbortWithStatus(http.StatusNoContent)
 }
 
 func optionsFeedbackEntry(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, PUT, PATCH, DELETE, OPTIONS")
-	ctx.AbortWithStatus(http.StatusNoContent)
 }
 
 func updateFeedbackUpvotes(ctx *gin.Context) {

--- a/routes/middleware.go
+++ b/routes/middleware.go
@@ -1,0 +1,23 @@
+/**
+ * file: router/middleware.go
+ * author: theo technicguy
+ * license: apache-2.0
+ *
+ * This file contains common middleware.
+ */
+
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// CommonHeaders is a common middleware inserting common headers
+// that should be included in every response from the server.
+func CommonHeaders(ctx *gin.Context) {
+	ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+	ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	ctx.Writer.Header().Set("Access-Control-Max-Age", "300")
+	ctx.Writer.Header().Set("X-Content-Type-Options", "nosniff")
+	ctx.Next()
+}

--- a/routes/middleware.go
+++ b/routes/middleware.go
@@ -9,6 +9,8 @@
 package routes
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,4 +22,8 @@ func CommonHeaders(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Access-Control-Max-Age", "300")
 	ctx.Writer.Header().Set("X-Content-Type-Options", "nosniff")
 	ctx.Next()
+}
+
+func Terminate(ctx *gin.Context) {
+	ctx.AbortWithStatus(http.StatusNoContent)
 }


### PR DESCRIPTION
Hi!

This PR splits the routes from the main file in the proof-of-concept to a separate module. In addition to that, there is a new endpoint to atomically increment feedback appreciations.